### PR TITLE
Support weird characters in secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Encrypts the plaintext using the secret.
 
 Decrypts the encrypted string using the secret.
 
+> [!NOTE]
+> The only difference from the AES implementation in the `crypto-js` library is that if there is a lone surrogate in a string, the `crypto-js` library crashes whereas this library replaces it with `U+FFFD`.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const crypto = require('node:crypto');
 // Refs: https://github.com/brix/crypto-js/issues/468#issuecomment-2060562277
 function encryptAES(plainText, secret) {
   const salt = crypto.randomBytes(8);
-  const password = Buffer.concat([Buffer.from(secret, 'binary'), salt]);
+  const password = Buffer.concat([Buffer.from(secret), salt]);
   const hash = [];
   let digest = password;
   for (let i = 0; i < 3; i++) {
@@ -28,7 +28,7 @@ function decryptAES(encryptedText, secret) {
   // From https://gist.github.com/chengen/450129cb95c7159cb05001cc6bdbf6a1
   const cypher = Buffer.from(encryptedText, 'base64');
   const salt = cypher.slice(8, 16);
-  const password = Buffer.concat([Buffer.from(secret, 'binary'), salt]);
+  const password = Buffer.concat([Buffer.from(secret), salt]);
   const md5Hashes = [];
   let digest = password;
   for (let i = 0; i < 3; i++) {

--- a/test.js
+++ b/test.js
@@ -20,3 +20,20 @@ describe('crypto-js compatibility', () => {
     strictEqual(decrypted, plainText);
   });
 });
+
+describe('weird characters in secret', () => {
+  const plainText = 'Hello, world!';
+  const secret = 'umm, šhhh ... 😀D◌̇랆탆𝐿 𑒹◌̴◌𑒺';
+
+  it('encrypted using crypto-js and decrypted using @raisinten/aes-crypto-js', () => {
+    const encrypted = CryptoJS.AES.encrypt(plainText, secret).toString();
+    const decrypted = decryptAES(encrypted.toString(), secret);
+    strictEqual(decrypted, plainText);
+  });
+
+  it('encrypted using @raisinten/aes-crypto-js and decrypted using crypto-js', () => {
+    const encrypted = encryptAES(plainText, secret);
+    const decrypted = CryptoJS.AES.decrypt(encrypted, secret).toString(CryptoJS.enc.Utf8);
+    strictEqual(decrypted, plainText);
+  });
+});


### PR DESCRIPTION
`'binary'` is not the right encoding for such characters in the `secret`. Using the default `'utf8'` encoding solves the issue.

![carbon](https://github.com/user-attachments/assets/0d84aaf2-314a-49ef-a2fa-f514276a73ec)
