### PR TITLE
Refactor encrypt and decrypt to be more similar

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,16 +4,16 @@ const crypto = require('node:crypto');
 function encryptAES(plainText, secret) {
   const salt = crypto.randomBytes(8);
   const password = Buffer.concat([Buffer.from(secret), salt]);
-  const hash = [];
+  const hashes = [];
   let digest = password;
   for (let i = 0; i < 3; i++) {
-    hash[i] = crypto.createHash('md5').update(digest).digest();
-    digest = Buffer.concat([hash[i], password]);
+    hashes[i] = crypto.createHash('md5').update(digest).digest();
+    digest = Buffer.concat([hashes[i], password]);
   }
-  const keyDerivation = Buffer.concat(hash);
-  const key = keyDerivation.subarray(0, 32);
-  const iv = keyDerivation.subarray(32);
+  const key = Buffer.concat([hashes[0], hashes[1]]);
+  const iv = hashes[2];
   const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+
   return Buffer.concat([
     Buffer.from('Salted__', 'utf8'),
     salt,
@@ -26,22 +26,22 @@ function encryptAES(plainText, secret) {
 function decryptAES(encryptedText, secret) {
   // From https://gist.github.com/schakko/2628689?permalink_comment_id=3321113#gistcomment-3321113
   // From https://gist.github.com/chengen/450129cb95c7159cb05001cc6bdbf6a1
-  const cypher = Buffer.from(encryptedText, 'base64');
-  const salt = cypher.slice(8, 16);
+  const encryptedTextAsBuffer = Buffer.from(encryptedText, 'base64');
+  const salt = encryptedTextAsBuffer.slice(8, 16);
+  const content = encryptedTextAsBuffer.slice(16);
   const password = Buffer.concat([Buffer.from(secret), salt]);
-  const md5Hashes = [];
+  const hashes = [];
   let digest = password;
   for (let i = 0; i < 3; i++) {
-    md5Hashes[i] = crypto.createHash('md5').update(digest).digest();
-    digest = Buffer.concat([md5Hashes[i], password]);
+    hashes[i] = crypto.createHash('md5').update(digest).digest();
+    digest = Buffer.concat([hashes[i], password]);
   }
-  const key = Buffer.concat([md5Hashes[0], md5Hashes[1]]);
-  const iv = md5Hashes[2];
-  const contents = cypher.slice(16);
+  const key = Buffer.concat([hashes[0], hashes[1]]);
+  const iv = hashes[2];
   const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
 
   return Buffer.concat([
-    decipher.update(contents),
+    decipher.update(content),
     decipher.final()
   ]).toString('utf8');
 }

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ function decryptAES(encryptedText, secret) {
   // From https://gist.github.com/schakko/2628689?permalink_comment_id=3321113#gistcomment-3321113
   // From https://gist.github.com/chengen/450129cb95c7159cb05001cc6bdbf6a1
   const encryptedTextAsBuffer = Buffer.from(encryptedText, 'base64');
-  const salt = encryptedTextAsBuffer.slice(8, 16);
-  const content = encryptedTextAsBuffer.slice(16);
+  const salt = encryptedTextAsBuffer.subarray(8, 16);
+  const content = encryptedTextAsBuffer.subarray(16);
   const password = Buffer.concat([Buffer.from(secret), salt]);
   const hashes = [];
   let digest = password;

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ describe('crypto-js compatibility', () => {
 
   it('encrypted using crypto-js and decrypted using @raisinten/aes-crypto-js', () => {
     const encrypted = CryptoJS.AES.encrypt(plainText, secret).toString();
-    const decrypted = decryptAES(encrypted.toString(), secret);
+    const decrypted = decryptAES(encrypted, secret);
     strictEqual(decrypted, plainText);
   });
 
@@ -27,7 +27,7 @@ describe('weird characters in secret', () => {
 
   it('encrypted using crypto-js and decrypted using @raisinten/aes-crypto-js', () => {
     const encrypted = CryptoJS.AES.encrypt(plainText, secret).toString();
-    const decrypted = decryptAES(encrypted.toString(), secret);
+    const decrypted = decryptAES(encrypted, secret);
     strictEqual(decrypted, plainText);
   });
 
@@ -44,7 +44,7 @@ describe('bytes corresponding to a single character that are split between two b
 
   it('encrypted using crypto-js and decrypted using @raisinten/aes-crypto-js', () => {
     const encrypted = CryptoJS.AES.encrypt(plainText, secret).toString();
-    const decrypted = decryptAES(encrypted.toString(), secret);
+    const decrypted = decryptAES(encrypted, secret);
     strictEqual(decrypted, plainText);
   });
 


### PR DESCRIPTION
Some steps in encryption and decryption are written differently, which confused me at first. I think like that the steps are easier to understand.

I also replaced `buf.slice` which is deprecated (https://nodejs.org/api/buffer.html#bufslicestart-end) and removed an unnecessary string conversion in the test.